### PR TITLE
Make it possible to disable console output on startup

### DIFF
--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/PSTerraSetup.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/PSTerraSetup.java
@@ -3,6 +3,7 @@ package com.alpsbte.alpslib.libpsterra.core;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.alpsbte.alpslib.libpsterra.utils.Utils;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -33,6 +34,9 @@ public class PSTerraSetup {
      * @throws Exception
      */
     public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version) throws Exception{
+        return setupPlugin(plugin, version, true);
+    }
+    public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version, boolean consoleOutput) throws Exception{
         PSTerraSetup result = new PSTerraSetup();
 
         
@@ -40,29 +44,30 @@ public class PSTerraSetup {
         String successPrefix = ChatColor.DARK_GRAY + "[" + ChatColor.DARK_GREEN + "✔" + ChatColor.DARK_GRAY + "] " + ChatColor.GRAY;
         String errorPrefix = ChatColor.DARK_GRAY + "[" + ChatColor.RED + "X" + ChatColor.DARK_GRAY + "] " + ChatColor.GRAY;
 
-        Bukkit.getConsoleSender().sendMessage(ChatColor.GOLD + "--------------- Plot-System-Terra V" + version + " ----------------");
-        Bukkit.getConsoleSender().sendMessage(ChatColor.DARK_GREEN + "Starting plugin...");
-        Bukkit.getConsoleSender().sendMessage(" ");
+        Utils.sendConsoleMessage(ChatColor.GOLD + "--------------- Plot-System-Terra V" + version + " ----------------", consoleOutput);
+        Utils.sendConsoleMessage(ChatColor.DARK_GREEN + "Starting plugin...", consoleOutput);
+        Utils.sendConsoleMessage(" ", consoleOutput);
 
         // Check for required dependencies, if it returns false disable plugin
         if (!DependencyManager.checkForRequiredDependencies(plugin)) {
-            Bukkit.getConsoleSender().sendMessage(errorPrefix + "Could not load required dependencies.");
-            Bukkit.getConsoleSender().sendMessage(ChatColor.YELLOW + "Missing Dependencies:");
-            DependencyManager.missingDependencies.forEach(dependency -> Bukkit.getConsoleSender().sendMessage(ChatColor.YELLOW + " - " + dependency));
+            Utils.sendConsoleMessage(errorPrefix + "Could not load required dependencies.", consoleOutput);
+            Utils.sendConsoleMessage(ChatColor.YELLOW + "Missing Dependencies:", consoleOutput);
+
+            DependencyManager.missingDependencies.forEach(dependency -> Utils.sendConsoleMessage(ChatColor.YELLOW + " - " + dependency, consoleOutput));
             throw new RuntimeException("Could not load required dependencies");
         }
-        Bukkit.getConsoleSender().sendMessage(successPrefix + "Successfully loaded required dependencies.");
+        Utils.sendConsoleMessage(successPrefix + "Successfully loaded required dependencies.", consoleOutput);
 
         // Load config
-        result.configManager = new ConfigManager(plugin);
-        Bukkit.getConsoleSender().sendMessage(successPrefix + "Successfully loaded configuration file.");
+        result.configManager = new ConfigManager(plugin, consoleOutput);
+        Utils.sendConsoleMessage(successPrefix + "Successfully loaded configuration file.", consoleOutput);
         result.configManager.reloadConfigs();
         FileConfiguration configFile = result.configManager.getConfig();
 
         // Initialize connection
 
 
-        Bukkit.getConsoleSender().sendMessage(successPrefix + "datamode:"+ configFile.getString(ConfigPaths.DATA_MODE));
+        Utils.sendConsoleMessage(successPrefix + "datamode:"+ configFile.getString(ConfigPaths.DATA_MODE), consoleOutput);
         if(configFile.getString(ConfigPaths.DATA_MODE).equalsIgnoreCase(DataMode.DATABASE.toString())){
 
             String URL = configFile.getString(ConfigPaths.DATABASE_URL);
@@ -72,7 +77,7 @@ public class PSTerraSetup {
             String teamApiKey = configFile.getString(ConfigPaths.API_KEY);
             
             result.connection = new DatabaseConnection(URL, name, username, password, teamApiKey);// DatabaseConnection.InitializeDatabase();
-            Bukkit.getConsoleSender().sendMessage(successPrefix + "Successfully initialized database connection.");
+            Utils.sendConsoleMessage(successPrefix + "Successfully initialized database connection.", consoleOutput);
         }else{
             String teamApiKey = configFile.getString(ConfigPaths.API_KEY);
             String apiHost = configFile.getString(ConfigPaths.API_URL);
@@ -83,27 +88,25 @@ public class PSTerraSetup {
             // String name = configFile.getString(ConfigPaths.DATABASE_NAME);
             // String username = configFile.getString(ConfigPaths.DATABASE_USERNAME);
             // String password = configFile.getString(ConfigPaths.DATABASE_PASSWORD);
-            Bukkit.getConsoleSender().sendMessage(successPrefix + "Successfully initialized API connection.");
-        
-
+            Utils.sendConsoleMessage(successPrefix + "Successfully initialized API connection.", consoleOutput);
         }
         if (result.connection == null)
             throw new RuntimeException("Connection initialization failed");
 
 
         //check FTP
-        FTPManager.testSFTPConnection_VFS2(result.connection);
-        Bukkit.getConsoleSender().sendMessage(successPrefix + "Successfully tested FTP connection.");
+        FTPManager.testSFTPConnection_VFS2(result.connection, consoleOutput);
+        Utils.sendConsoleMessage(successPrefix + "Successfully tested FTP connection.", consoleOutput);
             
         // Register event listeners
         plugin.getServer().getPluginManager().registerEvents(new EventListener(), plugin);
         plugin.getServer().getPluginManager().registerEvents(new MenuFunctionListener(), plugin);
-        Bukkit.getConsoleSender().sendMessage(successPrefix + "Successfully registered event listeners.");
+        Utils.sendConsoleMessage(successPrefix + "Successfully registered event listeners.", consoleOutput);
 
         result.plotCreator = new PlotCreator(plugin, configFile, result.connection);
 
         // Start checking for plots to paste
-        result.plotPaster = new PlotPaster(plugin, configFile, result.connection);
+        result.plotPaster = new PlotPaster(plugin, configFile, result.connection, consoleOutput);
         result.plotPaster.start();
 
 
@@ -113,7 +116,7 @@ public class PSTerraSetup {
         plugin.getCommand("createplot").setExecutor(new CMD_CreatePlot(result.plotCreator, result.connection, configFile));
         plugin.getCommand("pasteplot").setExecutor(new CMD_PastePlot(result.plotPaster, result.connection, configFile));
 
-        Bukkit.getConsoleSender().sendMessage(successPrefix + "Successfully registered commands.");
+        Utils.sendConsoleMessage(successPrefix + "Successfully registered commands.", consoleOutput);
 
 
         return result;

--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/config/ConfigManager.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/config/ConfigManager.java
@@ -1,5 +1,6 @@
 package com.alpsbte.alpslib.libpsterra.core.config;
 
+import com.alpsbte.alpslib.libpsterra.utils.Utils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.bukkit.Bukkit;
@@ -26,14 +27,18 @@ public class ConfigManager {
     private final List<Config> configs;
     private final String schematicsPath;
 
-    public ConfigManager(Plugin plugin) throws ConfigNotImplementedException {
+    private boolean consoleOutput = true;
+
+    public ConfigManager(Plugin plugin, boolean consoleOutput) throws ConfigNotImplementedException {
+        this.consoleOutput = consoleOutput;
+
         String absolutePluginDataPath = plugin.getDataFolder().getAbsolutePath();
         String fileName = "config.yml";
         
         InputStream defaultConfigResource =
             plugin.getResource("default" + fileName.substring(0, 1).toUpperCase() + fileName.substring(1));
         //create/init config list
-        configs = Collections.singletonList(
+        this.configs = Collections.singletonList(
                 new Config(fileName, absolutePluginDataPath, defaultConfigResource)
         );
 
@@ -46,13 +51,12 @@ public class ConfigManager {
 
 
         // Create schematics directory if not exists
-        schematicsPath = Paths.get(absolutePluginDataPath, "schematics") + File.separator;
+        this.schematicsPath = Paths.get(absolutePluginDataPath, "schematics") + File.separator;
     
 
         try {
-            if (!Files.isDirectory(Paths.get(schematicsPath))) {
-                Files.createDirectories(Paths.get(schematicsPath));
-            }
+            if (!Files.isDirectory(Paths.get(this.schematicsPath)))
+                Files.createDirectories(Paths.get(this.schematicsPath));
         } catch (IOException ex) {
             Bukkit.getLogger().log(Level.WARNING, "Could not create schematics directory!");
         }
@@ -122,7 +126,7 @@ public class ConfigManager {
                 lineNumber++;
 
                 if (line.contains("\t")) {
-                    Bukkit.getConsoleSender().sendMessage(ChatColor.RED + "Tab found in file \"" + config.getFile().getAbsolutePath() + "\" on line #" + lineNumber + "!");
+                    Utils.sendConsoleMessage(ChatColor.RED + "Tab found in file \"" + config.getFile().getAbsolutePath() + "\" on line #" + lineNumber + "!", consoleOutput);
                     throw new IllegalArgumentException("Tab found in file \"" + config.getFile().getAbsolutePath() + "\" on line # " + line + "!");
                 }
             }
@@ -193,10 +197,10 @@ public class ConfigManager {
 
             defaultFileLines.set(getIndex("config-version", defaultFileLines), "config-version: " + Config.VERSION);
             Files.write(config.getFile().toPath(), defaultFileLines);
-            Bukkit.getConsoleSender().sendMessage(ChatColor.YELLOW + "Updated " + config.getFileName() + " to version " + Config.VERSION + ".");
+            Utils.sendConsoleMessage(ChatColor.YELLOW + "Updated " + config.getFileName() + " to version " + Config.VERSION + ".", consoleOutput);
             return true;
         } catch (IOException ex) {
-            Bukkit.getLogger().log(Level.SEVERE, "An error occurred while updating config file!", ex);
+            Utils.sendConsoleError("An error occurred while updating config file!", ex, consoleOutput);
         }
         return false;
     }

--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/plotsystem/PlotPaster.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/plotsystem/PlotPaster.java
@@ -3,6 +3,7 @@ package com.alpsbte.alpslib.libpsterra.core.plotsystem;
 import com.alpsbte.alpslib.libpsterra.core.Connection;
 import com.alpsbte.alpslib.libpsterra.core.config.ConfigPaths;
 import com.alpsbte.alpslib.libpsterra.utils.FTPManager;
+import com.alpsbte.alpslib.libpsterra.utils.Utils;
 import com.sk89q.worldedit.*;
 import com.sk89q.worldedit.bukkit.BukkitWorld;
 import com.sk89q.worldedit.extent.clipboard.Clipboard;
@@ -36,9 +37,12 @@ public class PlotPaster extends Thread {
     private Connection connection;
     private final String schematicsPath;
 
-    public PlotPaster(Plugin plugin, FileConfiguration config, Connection connection) {
+    private boolean consoleOutput;
+
+    public PlotPaster(Plugin plugin, FileConfiguration config, Connection connection, boolean consoleOutput) {
         this.plugin = plugin;
         this.connection = connection;
+        this.consoleOutput = consoleOutput;
 
         this.serverName = config.getString(ConfigPaths.SERVER_NAME);
         this.fastMode = config.getBoolean(ConfigPaths.FAST_MODE);
@@ -75,7 +79,7 @@ public class PlotPaster extends Thread {
                         }//endif city is on this server
                         
                     } catch (Exception ex) {
-                        Bukkit.getLogger().log(Level.SEVERE, "An error occurred while pasting plot #" + plotID + "!", ex);
+                        Utils.sendConsoleError("An error occurred while pasting plot #" + plotID + "!", ex, consoleOutput);
                     }
 
                 }//endfor plots
@@ -84,9 +88,9 @@ public class PlotPaster extends Thread {
                     Bukkit.broadcastMessage("§7§l>§a Pasted §6" + pastedPlots + " §aplot" + (pastedPlots > 1 ? "s" : "") + "!");
                 }
 
-        } catch (Exception ex) {
-            Bukkit.getLogger().log(Level.SEVERE, "An error occurred while getting unpasted plots!", ex);
-        }
+            } catch (Exception ex) {
+                    Utils.sendConsoleError( "An error occurred while getting unpasted plots!", ex, consoleOutput);
+            }
         }, 0L, 20L * pasteInterval);
     }
 

--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/utils/FTPManager.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/utils/FTPManager.java
@@ -147,11 +147,11 @@ public class FTPManager {
         
     }
 
-    public static void testSFTPConnection_VFS2(Connection connection) throws Exception {
+    public static void testSFTPConnection_VFS2(Connection connection, boolean consoleOutput) throws Exception {
         //get ftpconfig from first country/server associated with the buildteam/apikey
         List<Country> teamCountries = connection.getTeamCountries();
         if (teamCountries.isEmpty()){
-            System.out.println("Cannot test FTP config - no countries/servers associated with API key");
+            Utils.sendConsoleMessage("Cannot test FTP config - no countries/servers associated with API key", consoleOutput);
             return;
         }
 
@@ -162,7 +162,7 @@ public class FTPManager {
 
         FTPConfiguration ftpConfiguration = connection.getFTPConfiguration(server.ftp_configuration_id);
 
-        System.out.println("Testing VFS2 sftp connect connect to " + ftpConfiguration.address + " with user " + ftpConfiguration.username);
+        Utils.sendConsoleMessage("Testing VFS2 sftp connect connect to " + ftpConfiguration.address + " with user " + ftpConfiguration.username, consoleOutput);
         
 
         fileManager.init();
@@ -194,7 +194,7 @@ public class FTPManager {
         //     content = content.concat(String.valueOf(c));
         // }
         fileManager.close();
-        System.out.println("FTP testfile exists: " +Boolean.toString(remote.exists()));
+        Utils.sendConsoleMessage("FTP testfile exists: " +Boolean.toString(remote.exists()), consoleOutput);
         
         
     }

--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/utils/Utils.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/utils/Utils.java
@@ -3,8 +3,11 @@ package com.alpsbte.alpslib.libpsterra.utils;
 import com.alpsbte.alpslib.libpsterra.core.config.ConfigPaths;
 import me.arcaniax.hdb.api.HeadDatabaseAPI;
 
+import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.logging.Level;
 
 
 public class Utils {
@@ -31,5 +34,20 @@ public class Utils {
 
     public static boolean hasPermission(CommandSender sender, String permissionNode) {
         return sender.hasPermission(permissionPrefix + "." + permissionNode);
+    }
+
+    public static void sendConsoleMessage(String message, boolean sendMessage){
+        if(sendMessage)
+            Bukkit.getConsoleSender().sendMessage(message);
+    }
+
+    public static void sendConsoleError(String error, Exception ex, boolean sendMessage){
+        if(sendMessage)
+            Bukkit.getLogger().log(Level.SEVERE, error, ex);
+    }
+
+    public static void sendConsoleWarning(String warning, Exception ex, boolean sendMessage){
+        if(sendMessage)
+            Bukkit.getLogger().log(Level.WARNING, warning, ex);
     }
 }


### PR DESCRIPTION
Alps-Lib is used by BuildTeamTools. When the BTT plugin starts, it uses its own console logging system. Once the PlotSystem Module of BTT is loaded though the console output of the PlotSystemTerra plugin of AlpsLib gets printed as well. 

This pull request makes it possible to disable the console output on plugin startup if needed. 