### PR TITLE
Make it possible to change config path on startup

### DIFF
--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/PSTerraSetup.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/PSTerraSetup.java
@@ -36,7 +36,7 @@ public class PSTerraSetup {
      * @throws Exception If an error occurs during setup
      */
     public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version) throws Exception{
-        return setupPlugin(plugin, version, true, null, null);
+        return setupPlugin(plugin, version, true, null, null, null);
     }
 
     /**
@@ -47,9 +47,12 @@ public class PSTerraSetup {
      * @param consoleOutput If console output should be enabled
      * @param configPath The path to the config file (null if default)
      * @param configFileName The name of the config file (null if default)
+     * @param defaultConfigFileName The name of the default config file (null if default)
      * @throws Exception If an error occurs during setup
      */
-    public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version, boolean consoleOutput, @Nullable String configPath, @Nullable String configFileName) throws Exception{
+    public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version, boolean consoleOutput,
+                                           @Nullable String configPath, @Nullable String configFileName, @Nullable String defaultConfigFileName) throws Exception{
+
         PSTerraSetup result = new PSTerraSetup();
 
         String successPrefix = ChatColor.DARK_GRAY + "[" + ChatColor.DARK_GREEN + "✔" + ChatColor.DARK_GRAY + "] " + ChatColor.GRAY;
@@ -70,7 +73,7 @@ public class PSTerraSetup {
         Utils.sendConsoleMessage(successPrefix + "Successfully loaded required dependencies.", consoleOutput);
 
         // Load config
-        result.configManager = new ConfigManager(plugin, consoleOutput, configPath, configFileName);
+        result.configManager = new ConfigManager(plugin, consoleOutput, configPath, configFileName, defaultConfigFileName);
         Utils.sendConsoleMessage(successPrefix + "Successfully loaded configuration file.", consoleOutput);
         result.configManager.reloadConfigs();
         FileConfiguration configFile = result.configManager.getConfig();

--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/PSTerraSetup.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/PSTerraSetup.java
@@ -29,17 +29,26 @@ public class PSTerraSetup {
     public ConfigManager configManager;
 
     /**
-     * creates/instantiates all the neccessary classes and event listeners required for plugin operation
-     * @param plugin
-     * @throws Exception
+     * creates/instantiates all the necessary classes and event listeners required for plugin operation
+     *
+     * @param plugin The plugin instance
+     * @throws Exception If an error occurs during setup
      */
     public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version) throws Exception{
-        return setupPlugin(plugin, version, true);
+        return setupPlugin(plugin, version, true, null);
     }
-    public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version, boolean consoleOutput) throws Exception{
-        PSTerraSetup result = new PSTerraSetup();
 
-        
+    /**
+     * creates/instantiates all the necessary classes and event listeners required for plugin operation
+     *
+     * @param plugin The plugin instance
+     * @param version The version of the plugin
+     * @param consoleOutput If console output should be enabled
+     * @param configPath The path to the config file (null if default)
+     * @throws Exception If an error occurs during setup
+     */
+    public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version, boolean consoleOutput, String configPath) throws Exception{
+        PSTerraSetup result = new PSTerraSetup();
 
         String successPrefix = ChatColor.DARK_GRAY + "[" + ChatColor.DARK_GREEN + "✔" + ChatColor.DARK_GRAY + "] " + ChatColor.GRAY;
         String errorPrefix = ChatColor.DARK_GRAY + "[" + ChatColor.RED + "X" + ChatColor.DARK_GRAY + "] " + ChatColor.GRAY;
@@ -59,7 +68,7 @@ public class PSTerraSetup {
         Utils.sendConsoleMessage(successPrefix + "Successfully loaded required dependencies.", consoleOutput);
 
         // Load config
-        result.configManager = new ConfigManager(plugin, consoleOutput);
+        result.configManager = new ConfigManager(plugin, consoleOutput, configPath);
         Utils.sendConsoleMessage(successPrefix + "Successfully loaded configuration file.", consoleOutput);
         result.configManager.reloadConfigs();
         FileConfiguration configFile = result.configManager.getConfig();

--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/PSTerraSetup.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/PSTerraSetup.java
@@ -21,6 +21,7 @@ import com.alpsbte.alpslib.libpsterra.core.plotsystem.PlotPaster;
 import com.alpsbte.alpslib.libpsterra.utils.FTPManager;
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
+import org.jetbrains.annotations.Nullable;
 
 public class PSTerraSetup {
     public PlotCreator plotCreator;
@@ -35,7 +36,7 @@ public class PSTerraSetup {
      * @throws Exception If an error occurs during setup
      */
     public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version) throws Exception{
-        return setupPlugin(plugin, version, true, null);
+        return setupPlugin(plugin, version, true, null, null);
     }
 
     /**
@@ -45,9 +46,10 @@ public class PSTerraSetup {
      * @param version The version of the plugin
      * @param consoleOutput If console output should be enabled
      * @param configPath The path to the config file (null if default)
+     * @param configFileName The name of the config file (null if default)
      * @throws Exception If an error occurs during setup
      */
-    public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version, boolean consoleOutput, String configPath) throws Exception{
+    public static PSTerraSetup setupPlugin(JavaPlugin plugin, String version, boolean consoleOutput, @Nullable String configPath, @Nullable String configFileName) throws Exception{
         PSTerraSetup result = new PSTerraSetup();
 
         String successPrefix = ChatColor.DARK_GRAY + "[" + ChatColor.DARK_GREEN + "✔" + ChatColor.DARK_GRAY + "] " + ChatColor.GRAY;
@@ -68,7 +70,7 @@ public class PSTerraSetup {
         Utils.sendConsoleMessage(successPrefix + "Successfully loaded required dependencies.", consoleOutput);
 
         // Load config
-        result.configManager = new ConfigManager(plugin, consoleOutput, configPath);
+        result.configManager = new ConfigManager(plugin, consoleOutput, configPath, configFileName);
         Utils.sendConsoleMessage(successPrefix + "Successfully loaded configuration file.", consoleOutput);
         result.configManager.reloadConfigs();
         FileConfiguration configFile = result.configManager.getConfig();

--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/config/ConfigManager.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/config/ConfigManager.java
@@ -29,10 +29,13 @@ public class ConfigManager {
 
     private boolean consoleOutput = true;
 
-    public ConfigManager(Plugin plugin, boolean consoleOutput) throws ConfigNotImplementedException {
+    public ConfigManager(Plugin plugin, boolean consoleOutput, String configPath) throws ConfigNotImplementedException {
         this.consoleOutput = consoleOutput;
 
         String absolutePluginDataPath = plugin.getDataFolder().getAbsolutePath();
+        if(configPath != null)
+            absolutePluginDataPath = absolutePluginDataPath + configPath;
+
         String fileName = "config.yml";
         
         InputStream defaultConfigResource =

--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/config/ConfigManager.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/config/ConfigManager.java
@@ -10,6 +10,7 @@ import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.NotNull;
 
 import com.alpsbte.alpslib.io.config.ConfigNotImplementedException;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.*;
 import java.nio.charset.StandardCharsets;
@@ -29,7 +30,7 @@ public class ConfigManager {
 
     private boolean consoleOutput = true;
 
-    public ConfigManager(Plugin plugin, boolean consoleOutput, String configPath) throws ConfigNotImplementedException {
+    public ConfigManager(Plugin plugin, boolean consoleOutput, @Nullable String configPath, @Nullable String configFileName) throws ConfigNotImplementedException {
         this.consoleOutput = consoleOutput;
 
         String absolutePluginDataPath = plugin.getDataFolder().getAbsolutePath();
@@ -37,6 +38,8 @@ public class ConfigManager {
             absolutePluginDataPath = absolutePluginDataPath + configPath;
 
         String fileName = "config.yml";
+        if(configFileName != null)
+            fileName = configFileName;
         
         InputStream defaultConfigResource =
             plugin.getResource("default" + fileName.substring(0, 1).toUpperCase() + fileName.substring(1));

--- a/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/config/ConfigManager.java
+++ b/libpsterra/src/main/java/com/alpsbte/alpslib/libpsterra/core/config/ConfigManager.java
@@ -30,7 +30,7 @@ public class ConfigManager {
 
     private boolean consoleOutput = true;
 
-    public ConfigManager(Plugin plugin, boolean consoleOutput, @Nullable String configPath, @Nullable String configFileName) throws ConfigNotImplementedException {
+    public ConfigManager(Plugin plugin, boolean consoleOutput, @Nullable String configPath, @Nullable String configFileName, @Nullable String defaultConfigFileName) throws ConfigNotImplementedException {
         this.consoleOutput = consoleOutput;
 
         String absolutePluginDataPath = plugin.getDataFolder().getAbsolutePath();
@@ -40,9 +40,13 @@ public class ConfigManager {
         String fileName = "config.yml";
         if(configFileName != null)
             fileName = configFileName;
+
+        String defaultFileName = "default" + fileName.substring(0, 1).toUpperCase() + fileName.substring(1);
+        if(defaultConfigFileName != null)
+            defaultFileName = defaultConfigFileName;
         
         InputStream defaultConfigResource =
-            plugin.getResource("default" + fileName.substring(0, 1).toUpperCase() + fileName.substring(1));
+            plugin.getResource(defaultFileName);
         //create/init config list
         this.configs = Collections.singletonList(
                 new Config(fileName, absolutePluginDataPath, defaultConfigResource)


### PR DESCRIPTION
Alps-Lib is used by BuildTeamTools. When the BTT plugin starts, PlotSystemTerra creates it own config, overwriting the existing BTT config.

This pull request makes it possible to put the config somewhere else, in this case in a `modules/plotsystem/` folder.