### PR TITLE
Use java 8 again for building except for npc module

### DIFF
--- a/hologram/pom.xml
+++ b/hologram/pom.xml
@@ -14,7 +14,9 @@
     <version>1.1.1</version>
 
     <properties>
+        <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <repositories>
@@ -79,15 +81,6 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
-                <configuration>
-                    <source>8</source>
-                    <target>8</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/http/pom.xml
+++ b/http/pom.xml
@@ -76,10 +76,9 @@
     </build>
 
     <properties>
+        <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
 
         <junit.jupiter.version>5.11.4</junit.jupiter.version>
         <kotlin.version>2.0.21</kotlin.version>

--- a/io/pom.xml
+++ b/io/pom.xml
@@ -14,9 +14,9 @@
     <version>1.1.0</version>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <repositories>

--- a/libpsterra/pom.xml
+++ b/libpsterra/pom.xml
@@ -11,12 +11,12 @@
 
     <artifactId>alpslib-libpsterra</artifactId>
     <name>AlpsLib-LibPlotSystemTerra</name>
-    <version>1.1.2</version>
+    <version>1.1.3</version>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <repositories>
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>com.alpsbte.alpslib</groupId>
             <artifactId>alpslib-utils</artifactId>
-            <version>1.3.4</version>
+            <version>1.3.5</version>
         </dependency>
 
         <!-- io from AlpsLib for config -->
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.3.0</version>
+            <version>7.3.9</version>
             <scope>provided</scope>
         </dependency>
 
@@ -115,30 +115,30 @@
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
-            <version>9.9.0</version>
+            <version>13.0.0</version>
         </dependency>
 
-        <!-- MariaDB Connector -->
+        <!-- MariaDB Connector Ref: https://mvnrepository.com/artifact/org.mariadb.jdbc/mariadb-java-client -->
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>3.4.1</version>
+            <version>3.5.2</version>
             <scope>compile</scope>
         </dependency>
 
-        <!-- Hikari-CP (MariaDB) -->
+        <!-- Hikari-CP (MariaDB) Ref: https://github.com/brettwooldridge/HikariCP/tags-->
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
-            <version>5.1.0</version>
+            <version>6.2.1</version>
             <scope>compile</scope>
         </dependency>
 
-        <!-- Apache Commons VFS -->
+        <!-- Apache Commons VFS Ref: https://mvnrepository.com/artifact/org.apache.commons/commons-vfs2 -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-vfs2</artifactId>
-            <version>2.9.0</version>
+            <version>2.10.0</version>
             <scope>compile</scope>
         </dependency>
 
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>3.11.0</version>
+            <version>3.11.1</version>
             <scope>compile</scope>
         </dependency>
 
@@ -154,7 +154,7 @@
         <dependency>
             <groupId>com.github.mwiede</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.2.18</version>
+            <version>0.2.23</version>
             <scope>compile</scope>
         </dependency>
 
@@ -163,7 +163,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.16.1</version>
+            <version>2.18.0</version>
             <scope>compile</scope>
         </dependency>
 
@@ -171,7 +171,7 @@
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>26.0.1</version>
+            <version>26.0.2</version>
             <scope>compile</scope>
         </dependency>
 
@@ -186,20 +186,20 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.10.3</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-runner</artifactId>
-            <version>1.10.2</version>
+            <version>1.12.0</version>
             <scope>test</scope>
         </dependency>
         <!-- junit matcher for object value comparison -->
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-            <version>2.0.0.0</version>
+            <artifactId>hamcrest</artifactId>
+            <version>3.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -213,7 +213,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.0</version>
+                <version>3.5.2</version>
                 <!-- set to true to skip tests -->
                 <configuration>
                     <skipTests>true</skipTests>
@@ -222,7 +222,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.5.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/npc/pom.xml
+++ b/npc/pom.xml
@@ -20,12 +20,6 @@
     </properties>
 
     <repositories>
-        <!-- TODO: Remove then when repo get hosted -->
-        <repository>
-            <id>fancyplugins-releases</id>
-            <name>FancyPlugins Repository</name>
-            <url>https://repo.fancyplugins.de/releases</url>
-        </repository>
         <repository>
             <id>alpsbte-repo</id>
             <url>https://mvn.alps-bte.com/repository/alps-bte/</url>
@@ -60,7 +54,7 @@
         <dependency>
             <groupId>de.oliver</groupId>
             <artifactId>FancyNpcs</artifactId>
-            <version>2.3.0</version>
+            <version>2.4.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/npc/pom.xml
+++ b/npc/pom.xml
@@ -14,9 +14,9 @@
     <version>1.0.37</version>
 
     <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.release>21</maven.compiler.release> <!-- Java Records are not in API  for 1.8 so using newer-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <repositories>

--- a/utils/pom.xml
+++ b/utils/pom.xml
@@ -11,12 +11,12 @@
 
     <artifactId>alpslib-utils</artifactId>
     <name>AlpsLib-Utils</name>
-    <version>1.3.4</version>
+    <version>1.3.5</version>
 
     <properties>
-        <maven.compiler.target>21</maven.compiler.target>
-        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
     <repositories>
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>com.github.cryptomorin</groupId>
             <artifactId>XSeries</artifactId>
-            <version>9.9.0</version>
+            <version>13.0.0</version>
         </dependency>
 
         <!-- HeadDatabase-API -->
@@ -64,7 +64,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.6.0</version>
                 <configuration>
                     <outputDirectory>${project.build.directory}/shaded/</outputDirectory>
                     <filters>

--- a/utils/src/main/java/com/alpsbte/alpslib/utils/item/ItemBuilder.java
+++ b/utils/src/main/java/com/alpsbte/alpslib/utils/item/ItemBuilder.java
@@ -24,7 +24,6 @@
 
 package com.alpsbte.alpslib.utils.item;
 
-import com.alpsbte.alpslib.utils.AlpsUtils;
 import net.kyori.adventure.text.TextComponent;
 import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.*;
@@ -33,6 +32,7 @@ import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.components.CustomModelDataComponent;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +44,7 @@ public class ItemBuilder {
     private final ItemStack item;
     protected final ItemMeta itemMeta;
 
-    public ItemBuilder(ItemStack item) {
+    public ItemBuilder(@NotNull ItemStack item) {
         itemMeta = item.getItemMeta();
         if (itemMeta != null) itemMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         this.item = item;
@@ -77,7 +77,7 @@ public class ItemBuilder {
     }
 
     @Deprecated
-    public ItemBuilder setLore(List<String> lore) {
+    public ItemBuilder setLore(@NotNull List<String> lore) {
         List<TextComponent> components = new ArrayList<>();
         for (String loreStr : lore)
             components.add(LORE_COMPONENT.append(LegacyComponentSerializer.legacySection().deserialize(loreStr)));
@@ -122,10 +122,10 @@ public class ItemBuilder {
      */
     public ItemBuilder setItemModel(Object model) {
 
-        if (model instanceof Integer modelInt) {
-            setItemModel((int)modelInt);
-        } else if (model instanceof String modelString) {
-            setItemModel(modelString);
+        if (model instanceof Integer) {
+            setItemModel((int)model);
+        } else if (model instanceof String) {
+            setItemModel((String)model);
         }
         return this;
     }


### PR DESCRIPTION
Needed for multiversion libpsterra because Minecraft 1.12 (which is the target because of CubicChunks Mod) runs default with Java 8. Also fixes that npc module uses a wrong version.