### PR TITLE
Add directional generator utility helpers

### DIFF
--- a/utils/build.gradle.kts
+++ b/utils/build.gradle.kts
@@ -14,4 +14,4 @@ dependencies {
 }
 
 description = "AlpsLib-Utils"
-version = "1.4.5"
+version = "1.4.6"

--- a/utils/src/main/java/com/alpsbte/alpslib/utils/GeneratorUtils.java
+++ b/utils/src/main/java/com/alpsbte/alpslib/utils/GeneratorUtils.java
@@ -8,6 +8,7 @@ import clipper2.offset.EndType;
 import clipper2.offset.JoinType;
 import com.cryptomorin.xseries.XMaterial;
 import com.fastasyncworldedit.core.limit.FaweLimit;
+import com.fastasyncworldedit.core.registry.state.PropertyKey;
 import com.sk89q.worldedit.*;
 import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.extension.factory.MaskFactory;
@@ -36,6 +37,7 @@ import com.sk89q.worldedit.regions.selector.CuboidRegionSelector;
 import com.sk89q.worldedit.regions.selector.Polygonal2DRegionSelector;
 import com.sk89q.worldedit.session.ClipboardHolder;
 import com.sk89q.worldedit.session.SessionManager;
+import com.sk89q.worldedit.util.Direction;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockType;
 import com.sk89q.worldedit.world.block.BlockTypes;
@@ -217,11 +219,11 @@ public class GeneratorUtils {
 
 
 
-    
+
     /*=============================================**
-    
+
                 SCRIPT HELPER FUNCTIONS
-    
+
      **=============================================*/
 
     /**
@@ -291,7 +293,54 @@ public class GeneratorUtils {
 
         return blockStates;
     }
-    
+
+    /**
+     * Returns the default block state of a directional block with the facing property set.
+     *
+     * @param blockType The block type to create the state from
+     * @param facing The facing direction to apply
+     * @return The block state with the facing property set
+     */
+    public static BlockState getBlockStateWithFacing(BlockType blockType, Direction facing) {
+        if (blockType == null || facing == null) return null;
+
+        return blockType.getDefaultState().with(PropertyKey.FACING, facing);
+    }
+
+    /**
+     * Returns the cardinal facing from one vector to another.
+     *
+     * @param from The start vector
+     * @param to The target vector
+     * @param fallbackFacing The direction to use when the vectors have no clear horizontal direction
+     * @return The best matching cardinal direction
+     */
+    public static Direction getFacing(Vector from, Vector to, Direction fallbackFacing) {
+        if (from == null || to == null) return fallbackFacing;
+
+        return getFacing(to.getBlockX() - from.getBlockX(), to.getBlockZ() - from.getBlockZ(), fallbackFacing);
+    }
+
+    /**
+     * Returns the cardinal facing for a horizontal delta.
+     *
+     * @param deltaX The X delta
+     * @param deltaZ The Z delta
+     * @param fallbackFacing The direction to use when the delta has no dominant horizontal axis
+     * @return The best matching cardinal direction
+     */
+    public static Direction getFacing(int deltaX, int deltaZ, Direction fallbackFacing) {
+        if (deltaX == 0 && deltaZ == 0) return fallbackFacing;
+
+        if (Math.abs(deltaX) > Math.abs(deltaZ)) return deltaX >= 0 ? Direction.EAST : Direction.WEST;
+
+        if (Math.abs(deltaZ) > Math.abs(deltaX)) return deltaZ >= 0 ? Direction.SOUTH : Direction.NORTH;
+
+        if (fallbackFacing != null) return fallbackFacing;
+
+        return deltaZ >= 0 ? Direction.SOUTH : Direction.NORTH;
+    }
+
 
 
     /*=============================================**
@@ -316,17 +365,17 @@ public class GeneratorUtils {
     }
 
 
-    
-    
-    
+
+
+
     /*=============================================**
-    
+
                WORLDEDIT REGION FUNCTIONS
-    
+
      **=============================================*/
-    
-    
-    
+
+
+
     /**
      * Returns the WorldEdit selection Vector from a player no matter which type of selection the player made.
      *
@@ -418,9 +467,9 @@ public class GeneratorUtils {
 
     /**
      * Returns the minimum and maximum points of a region as a Vector array.
-     * 
+     *
      * @param region The region to get the minimum and maximum points from
-     * @return A Vector array with the minimum vector at index 0 and the maximum vector at index 1             
+     * @return A Vector array with the minimum vector at index 0 and the maximum vector at index 1
      */
     public static Vector[] getMinMaxPoints(Region region){
         Vector[] minMax = new Vector[2];
@@ -520,7 +569,7 @@ public class GeneratorUtils {
                 for (Block block : block1D) {
                     ItemStack item = xMaterial.parseItem();
                     if (block != null && item != null && block.getType() == item.getType())
-                            amountFound++;
+                        amountFound++;
                 }
 
         return amountFound >= requiredAmount;
@@ -664,19 +713,19 @@ public class GeneratorUtils {
         return null;
     }
 
-    
+
 
 
 
 
 
     /*=============================================**
-    
+
                 WORLDEDIT OPERATION FUNCTIONS
-    
+
      **=============================================*/
-    
-    
+
+
 
     /**
      * Prepares a script session by expanding the selection, removing non-solid blocks and ignored materials.
@@ -705,7 +754,7 @@ public class GeneratorUtils {
 
         if(removeNonSolidBlocks)
             replaceBlocksWithMasks(localSession, actor, world, Collections.singletonList("!#solid"), null, new BlockState[]{air.getDefaultState()}, 1)
-                .join();
+                    .join();
 
         if(removeIgnoredMaterials) {
             Material[] materials = getIgnoredMaterials();
@@ -718,7 +767,7 @@ public class GeneratorUtils {
                 List<BlockState> blockStates = blockType.getAllStates();
                 BlockState[] blockStatesArray = blockStates.toArray(new BlockState[0]);
                 replaceBlocks(localSession, actor, world, blockStatesArray, new BlockState[]{air.getDefaultState()})
-                    .join();
+                        .join();
             }
         }
 
@@ -730,7 +779,7 @@ public class GeneratorUtils {
         return regionBlocks;
     }
 
-    
+
 
     /** Analyzes a region and returns a three-dimensional array of all blocks in the region.
      * The size of the array is defined by the width, height and length of the region from WorldEdit of the player.
@@ -889,7 +938,7 @@ public class GeneratorUtils {
      */
     public static CompletableFuture<Void> replaceBlocksWithMasks(LocalSession localSession, Actor actor, com.sk89q.worldedit.world.World weWorld, List<String> masks, BlockState from, BlockState[] to, int iterations) {
         if(to == null || to.length == 0)
-                throw new IllegalArgumentException("BlockState[] to is empty");
+            throw new IllegalArgumentException("BlockState[] to is empty");
 
         CompletableFuture<Void> future = new CompletableFuture<>();
         Bukkit.getScheduler().runTaskAsynchronously(getPlugin(), () -> {
@@ -1378,11 +1427,11 @@ public class GeneratorUtils {
     }
 
     /**
-    * Redoes the last action of a LocalSession.
-    * @param session The local session to redo the last action of
-    * @param player The player who created the structure
-    * @param amount The amount of actions to redo
-    */
+     * Redoes the last action of a LocalSession.
+     * @param session The local session to redo the last action of
+     * @param player The player who created the structure
+     * @param amount The amount of actions to redo
+     */
     public static void redo(LocalSession session, Player player, Actor actor, int amount){
         com.sk89q.worldedit.entity.Player wePlayer = BukkitAdapter.adapt(player);
 
@@ -1730,7 +1779,7 @@ public class GeneratorUtils {
 
             return resultVectors.get(longestPathIndex);
 
-        // Otherwise, return all paths combined into one
+            // Otherwise, return all paths combined into one
         }else{
             List<Vector> result = new ArrayList<>();
             for(List<Vector> vectorList : resultVectors)

--- a/utils/src/main/java/com/alpsbte/alpslib/utils/GeneratorUtils.java
+++ b/utils/src/main/java/com/alpsbte/alpslib/utils/GeneratorUtils.java
@@ -115,6 +115,7 @@ import java.util.concurrent.CompletableFuture;
  * <br>• {@link #drawLineWithMasks(LocalSession, Actor, com.sk89q.worldedit.world.World, Block[][][], List, Vector, Vector, BlockState[], boolean)}
  * <br>• {@link #pasteSchematicWithMasks(LocalSession, Actor, com.sk89q.worldedit.world.World, Block[][][], List, String, Location, double)}
  * <br>• {@link #pasteSchematic(LocalSession, Actor, com.sk89q.worldedit.world.World, Block[][][], String, Location, double)}
+ * <br>• {@link #setBlockStatesAtPositions(LocalSession, Actor, com.sk89q.worldedit.world.World, List, List)}
  * <br>• {@link #expandSelection(LocalSession, Vector)}
  * <br>• {@link #clearHistory(LocalSession)}
  * <br>• {@link #undo(LocalSession, Player, Actor, int)}
@@ -124,6 +125,12 @@ import java.util.concurrent.CompletableFuture;
  *
  * <br><br><b>Vector Helper Functions</b>:
  * <br>• {@link #adjustHeight(List, Block[][][])}
+ * <br>• {@link #toBlockVector(Vector)}
+ * <br>• {@link #copyToBlockVectors(List)}
+ * <br>• {@link #createShortestBlockPath(List)}
+ * <br>• {@link #appendShortestBlockLine(List, Vector, Vector)}
+ * <br>• {@link #removeOrthogonalCorners(List)}
+ * <br>• {@link #createBoundsSelectionPoints(List, int)}
  * <br>• {@link #populatePoints(List, int)}
  * <br>• {@link #reducePoints(List, int, int)}
  * <br>• {@link #extendPolyLine(List)}
@@ -1493,6 +1500,53 @@ public class GeneratorUtils {
         editSession.close();
     }
 
+    /**
+     * Sets individual block states at exact positions and stores the operation in the player's WorldEdit history.
+     *
+     * @param localSession The WorldEdit local session
+     * @param actor        The WorldEdit actor
+     * @param weWorld      The WorldEdit world
+     * @param positions    The block positions to change
+     * @param blockStates  The block states to place at the matching positions
+     * @return A CompletableFuture that completes when the operation is finished
+     */
+    public static CompletableFuture<Void> setBlockStatesAtPositions(
+            LocalSession localSession,
+            Actor actor,
+            com.sk89q.worldedit.world.World weWorld,
+            List<Vector> positions,
+            List<BlockState> blockStates
+    ) {
+        if (positions.size() != blockStates.size())
+            throw new IllegalArgumentException("Position and BlockState lists must have the same size");
+
+        CompletableFuture<Void> future = new CompletableFuture<>();
+
+        Bukkit.getScheduler().runTaskAsynchronously(getPlugin(), () -> {
+            try (EditSession editSession = WorldEdit.getInstance().newEditSession(weWorld)) {
+                for (int index = 0; index < positions.size(); index++) {
+                    BlockState blockState = blockStates.get(index);
+
+                    if (blockState == null)
+                        continue;
+
+                    Vector position = positions.get(index);
+                    editSession.setBlock(
+                            BlockVector3.at(position.getBlockX(), position.getBlockY(), position.getBlockZ()),
+                            (Pattern) blockState
+                    );
+                }
+
+                saveEditSession(editSession, localSession, actor);
+                future.complete(null);
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+
+        return future;
+    }
+
 
 
 
@@ -1516,6 +1570,166 @@ public class GeneratorUtils {
     public static void adjustHeight(List<Vector> points, Block[][][] blocks){
         for (Vector point : points)
             point.setY(getMaxHeight(blocks, point.getBlockX(), point.getBlockZ(), getIgnoredMaterials()));
+    }
+
+    /**
+     * Returns a new vector snapped to integer block coordinates.
+     *
+     * @param vector The vector to snap
+     * @return A vector using the input's block coordinates
+     */
+    public static Vector toBlockVector(Vector vector) {
+        return new Vector(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ());
+    }
+
+    /**
+     * Copies the given vectors and snaps every copy to integer block coordinates.
+     *
+     * @param vectors The vectors to copy
+     * @return A copied list using block coordinates
+     */
+    public static List<Vector> copyToBlockVectors(List<Vector> vectors) {
+        List<Vector> copiedVectors = new ArrayList<>();
+
+        for (Vector vector : vectors)
+            copiedVectors.add(toBlockVector(vector));
+
+        return copiedVectors;
+    }
+
+    /**
+     * Checks whether two vectors point to the same block coordinate.
+     *
+     * @param first  The first vector
+     * @param second The second vector
+     * @return Whether both vectors have the same block coordinates
+     */
+    public static boolean isSameBlock(Vector first, Vector second) {
+        return first.getBlockX() == second.getBlockX()
+                && first.getBlockY() == second.getBlockY()
+                && first.getBlockZ() == second.getBlockZ();
+    }
+
+    /**
+     * Creates a block-by-block path through the given control points.
+     *
+     * @param points The control points to connect
+     * @return The shortest block path connecting the points
+     */
+    public static List<Vector> createShortestBlockPath(List<Vector> points) {
+        List<Vector> path = new ArrayList<>();
+
+        if (points.isEmpty())
+            return path;
+
+        path.add(toBlockVector(points.getFirst()));
+
+        for (int index = 0; index < points.size() - 1; index++)
+            appendShortestBlockLine(path, points.get(index), points.get(index + 1));
+
+        return path;
+    }
+
+    /**
+     * Appends the shortest horizontal block line between two points to an existing path.
+     *
+     * @param path  The path to append to
+     * @param start The start point
+     * @param end   The end point
+     */
+    public static void appendShortestBlockLine(List<Vector> path, Vector start, Vector end) {
+        int deltaX = end.getBlockX() - start.getBlockX();
+        int deltaY = end.getBlockY() - start.getBlockY();
+        int deltaZ = end.getBlockZ() - start.getBlockZ();
+        int horizontalSteps = Math.max(Math.abs(deltaX), Math.abs(deltaZ));
+
+        if (horizontalSteps == 0) {
+            Vector blockPoint = toBlockVector(end);
+
+            if (path.isEmpty())
+                path.add(blockPoint);
+            else
+                path.set(path.size() - 1, blockPoint);
+
+            return;
+        }
+
+        for (int step = 1; step <= horizontalSteps; step++) {
+            double progress = step / (double) horizontalSteps;
+            path.add(new Vector(
+                    start.getBlockX() + (int) Math.round(deltaX * progress),
+                    start.getBlockY() + (int) Math.round(deltaY * progress),
+                    start.getBlockZ() + (int) Math.round(deltaZ * progress)
+            ));
+        }
+    }
+
+    /**
+     * Removes orthogonal corner points from a block path.
+     *
+     * @param path The path to smooth
+     * @return A path without blocky right-angle corner duplicates
+     */
+    public static List<Vector> removeOrthogonalCorners(List<Vector> path) {
+        List<Vector> result = new ArrayList<>();
+
+        for (int index = 0; index < path.size(); index++) {
+            if (index > 0 && index < path.size() - 1 && isOrthogonalCorner(path.get(index - 1), path.get(index), path.get(index + 1)))
+                continue;
+
+            result.add(path.get(index));
+        }
+
+        return result;
+    }
+
+    /**
+     * Checks whether a point is a right-angle corner between its neighbors.
+     *
+     * @param previous The previous point
+     * @param current  The current point
+     * @param next     The next point
+     * @return Whether the current point is an orthogonal corner
+     */
+    public static boolean isOrthogonalCorner(Vector previous, Vector current, Vector next) {
+        int previousDx = Integer.compare(current.getBlockX() - previous.getBlockX(), 0);
+        int previousDz = Integer.compare(current.getBlockZ() - previous.getBlockZ(), 0);
+        int nextDx = Integer.compare(next.getBlockX() - current.getBlockX(), 0);
+        int nextDz = Integer.compare(next.getBlockZ() - current.getBlockZ(), 0);
+
+        return (previousDx != 0 || previousDz != 0)
+                && (nextDx != 0 || nextDz != 0)
+                && previousDx * nextDx + previousDz * nextDz == 0
+                && previousDx != nextDx
+                && previousDz != nextDz;
+    }
+
+    /**
+     * Creates a flat rectangular polygon that bounds the given points with padding.
+     *
+     * @param points  The points to bound
+     * @param padding The horizontal padding around the bounds
+     * @return Four points describing the padded bounds
+     */
+    public static List<Vector> createBoundsSelectionPoints(List<Vector> points, int padding) {
+        int minX = Integer.MAX_VALUE;
+        int minZ = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxZ = Integer.MIN_VALUE;
+
+        for (Vector point : points) {
+            minX = Math.min(minX, point.getBlockX() - padding);
+            minZ = Math.min(minZ, point.getBlockZ() - padding);
+            maxX = Math.max(maxX, point.getBlockX() + padding);
+            maxZ = Math.max(maxZ, point.getBlockZ() + padding);
+        }
+
+        return List.of(
+                new Vector(minX, 0, minZ),
+                new Vector(maxX, 0, minZ),
+                new Vector(maxX, 0, maxZ),
+                new Vector(minX, 0, maxZ)
+        );
     }
 
     /** As long as two neighboring vectors are further than a given distance of blocks apart, add a new vector in between them
@@ -1832,7 +2046,7 @@ public class GeneratorUtils {
      * @param vectors The list of vectors to get the maximum height of
      * @return The maximum height
      */
-    private static int getMaxHeight(List<Vector> vectors){
+    public static int getMaxHeight(List<Vector> vectors){
         int maxHeight = Integer.MIN_VALUE;
         for(Vector vector : vectors)
             maxHeight = Math.max(maxHeight, vector.getBlockY());


### PR DESCRIPTION
## Summary
Adds shared `GeneratorUtils` helpers for directional block states and cardinal facing calculation.

## Changes
- Adds `getBlockStateWithFacing(...)` for directional blocks.
- Adds `getFacing(...)` helpers for vector-to-vector and delta-based direction lookup.
- Uses fallback directions when no clear horizontal direction exists.
